### PR TITLE
Add /live redirect to YT channel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -108,6 +108,14 @@ const moduleExports = {
         destination: '/api/sitemap.xml',
         permanent: true,
       },
+
+      // new external redirects
+      {
+        source: '/live',
+        destination:
+          'https://www.youtube.com/InternationalQuidditchAssociation',
+        permanent: false,
+      },
     ];
   },
   webpack(config) {


### PR DESCRIPTION
Reusing NextJS server side redirect functionality to redirect requests to `/live` to the YoutTube channel page.

This was the simplest way to support the ask of Lore to get a nice short url for livestream for the upcoming Continental Games.