### PR TITLE
Allow marking cards to be 4 in a row with format_metadata

### DIFF
--- a/components/prismic/cards.tsx
+++ b/components/prismic/cards.tsx
@@ -10,9 +10,18 @@ import { ReactElement } from 'react';
 const Card = dynamic(() => import('components/card'));
 const Slice = dynamic(() => import('components/slice'));
 
+const styleOverrides = {
+  fourInRow: {
+    gridItemMinSize: '260px',
+  },
+};
+
 function CardsSlice(rawData): ReactElement {
   const { primary, items = [] } = rawData;
-  const { title, content, variant } = primary;
+  const { title, content, variant, format_metadata } = primary;
+
+  const gridItemMinSize =
+    styleOverrides[format_metadata]?.gridItemMinSize || '300px';
 
   return (
     <Slice variant={variant}>
@@ -35,7 +44,7 @@ function CardsSlice(rawData): ReactElement {
       )}
 
       <Grid
-        gridTemplateColumns="repeat(auto-fit, minmax(300px, 1fr))"
+        gridTemplateColumns={`repeat(auto-fit, minmax(${gridItemMinSize}, 1fr))`}
         gridGap={8}
       >
         {items.map((item, i) => {


### PR DESCRIPTION
Apply `fourInRow` to a card in Prismic to trigger
![image](https://github.com/iqasport/iqasport.org/assets/10709060/505e7b2f-9e49-4806-86ab-6f7cb5baf25a)
![image](https://github.com/iqasport/iqasport.org/assets/10709060/abd90c05-a6c5-4ab6-8d25-525f6f49a4b6)
